### PR TITLE
Add support for many Portal 2 mods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.xml]
+indent_style = space
+indent_size = 4

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18902,4 +18902,15 @@
         <Type>Script</Type>
         <Description>Load Removal and Auto Splitting is available. (by xCape)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Syobon Action</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/neon-uriel/asl/main/syobon_action/syobon.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter is available. (By neon_uriel)</Description>
+        <Website>https://github.com/neon-uriel/asl/blob/main/syobon_action/README.md</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
-   <AutoSplitter>    
+    <AutoSplitter>    
+        <Games>
+            <Game>Dead From Beyond</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Dead%20From%20Beyond/deadfrombeyond.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start/split is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>    
         <Games>
             <Game>Fractured Minds</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Stairway to Heaven's Gate</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/Stairway/StairwayToHeaven.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and IGT is available. (By Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/Stairway/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>LEGO Alpha Team</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Ratchet &amp; Clank: Rift Apart</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Syn34/Rift-Apart-Autosplitter/main/Riftsplitter%20v13%20by%20Jasper%20%26%20Sin.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Supports Splitting and Load Removal for v1.728.0.0</Description> 
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Bloodline</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+    <AutoSplitter>    
+        <Games>
+            <Game>DREDGE</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/phrayse/DREDGE/main/DREDGE.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplit and load removal for patch 1.2.0+ by Phrayse</Description>
+    </AutoSplitter>
 	<AutoSplitter>
         <Games>
             <Game>Moose Lost in the Woods</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -8646,6 +8646,18 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Sonic Suggests</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/Refragg/sonic-suggests-autosplitter/releases/download/latest/sonic_suggests_autosplitter.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Website>https://github.com/Refragg/sonic-suggests-autosplitter/</Website>
+        <ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Automatic start/split/reset (By Refrag)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Firewing 64</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -22,6 +22,17 @@
         <Type>Script</Type>
         <Description>Autosplitting and load removal is available (Demo Only). (By diggity)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Echo Point Nova (Demo)</Game>
+            <Game>Echo Point Nova</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Echo%20Point%20Nova/echopointnovademo.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting is available. (By diggity)</Description>
+    </AutoSplitter>
     <AutoSplitter>    
         <Games>
             <Game>Dead From Beyond</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+	<AutoSplitter>
+        <Games>
+            <Game>DMZ: North Korea</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/DMZ%20North%20Korea/DMZNorthKorea.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and Load removal is available. (By Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/DMZ%20North%20Korea/README.md</Website>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Raw Nerve</Game>
@@ -31,7 +42,7 @@
             <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.EnGardeDemo/main/EnGarde.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load removal is available. (By Meta)</Description>
+        <Description>Autosplitting and Load removal is available. (By Biksel, Meta)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13,6 +13,16 @@
     </AutoSplitter>
     <AutoSplitter>    
         <Games>
+            <Game>Trepang2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.Trepang2/main/Trepang2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description> Contains functionality for autostart, autosplit, and load removal (By Meta)</Description>
+   </AutoSplitter>
+   <AutoSplitter>    
+        <Games>
             <Game>Fractured Minds</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
-	<AutoSplitter>    
+	<AutoSplitter>
+        <Games>
+            <Game>Strike Force Heroes Remake</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/Strike%20Force%20Heroes%20Remake/SFHRemake.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter is available. (By Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/Strike%20Force%20Heroes%20Remake/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>    
         <Games>
             <Game>Duck Simulator 2</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -62,7 +62,7 @@
             <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.Trepang2/main/Trepang2.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description> Contains functionality for autostart, autosplit, and load removal (By Meta)</Description>
+        <Description> Contains functionality for autostart, autosplit, and load removal (By Meta &amp; Diggity)</Description>
    </AutoSplitter>
    <AutoSplitter>    
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+     <AutoSplitter>
+        <Games>
+            <Game>En Garde! (Demo)</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.EnGardeDemo/main/EnGarde.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load removal is available. (By Meta)</Description>
+    </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Hitman 3 Freelancer</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18752,4 +18752,17 @@
 	<Description>Planet of Lana Autosplitter and Load Remover (by Penta)</Description>
 	<Website>https://www.speedrun.com/planet_of_lana</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>NEO: The World Ends With You</Game>
+            <Game>neotwewy</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TheTedder/LiveSplit.NEOTWEWY/v1.0.0/neotwewy.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+	<Type>Script</Type>
+	<Description>NEO: The World Ends With You Autosplitter and Load Remover (by Tedder)</Description>
+	<Website>https://www.speedrun.com/neotwewy</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1240,28 +1240,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Ninja Gaiden Sigma</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/RazRaz94/autosplitters/main/NinjaGaidenSigmaAutoSplitterLRT_By%20Mysterion_06_.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitting and load removal is available. (by Mysterion_06_ and LonerHero)</Description>
-        <Website>https://www.speedrun.com/ninja_gaiden_sigma</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Ninja Gaiden Sigma 2</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/RazRaz94/autosplitters/main/Ninja%20Gaiden%20Sigma%202%20Autosplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter for Ninja Gaiden Sigma 2 By LonerHero and Mysterion_06_</Description>
-        <Website>https://www.speedrun.com/ninja_gaiden_sigma_2</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Crypt</Game>
         </Games>
         <URLs>
@@ -5218,18 +5196,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>The Evil Within 2</Game>
-            <Game>Evil Within 2</Game>
-            <Game>EW2</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/TheEvilWithin2.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitter/Load Removal is available. (By Mysterion_06_, Kuno Demetries, Dread)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Star Wars Jedi Knight: Jedi Academy</Game>
             <Game>SWJKJA</Game>
             <Game>JKJA</Game>
@@ -5257,18 +5223,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Auto Splitting and Load Removal are available. (By Dread, Zefie and Sphere)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Resident Evil 5</Game>
-            <Game>Resident Evil 5 (Steam)</Game>
-            <Game>RE5</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Resident-Evil-5/main/Splitter</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal are available. (By Mysterion_06_ &amp; TheDementedSalad)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -5891,22 +5845,6 @@
         <Type>Script</Type>
         <Description>Door and Item autosplits available for multiple routes. See Website for more detail. (by deserteagle417)</Description>
         <Website>https://github.com/deserteagle417/RE3-Autosplitter</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Resident Evil 4</Game>
-            <Game>Resident Evil 4 (Steam)</Game>
-            <Game>Resident Evil 4 Ultimate HD</Game>
-            <Game>RE4</Game>
-            <Game>Biohazard 4</Game>
-            <Game>Bio4</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Re4Splitter/main/RE4Splitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal are available. (By Wipefinger, Mysterion_06_, Yuushi)</Description>
-        <Website>https://github.com/Mysterion06/Re4Splitter/blob/main/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -7663,16 +7601,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Vanquish</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Vanquish/main/Vanquish.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter and Loadremover by Fog and Mysterion_06_</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Turok 2: Seeds of Evil</Game>
         </Games>
         <URLs>
@@ -8388,16 +8316,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting and load removal is available. (by SuicideMachine)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Bayonetta</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Bayonetta/main/Bayonetta.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with Loadremover by Mysterion_06_</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -9788,17 +9706,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Devil May Cry 2</Game>
-            <Game>DMC2</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/DMC2Splitter/master/DMC2.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter by Auddy and Mysterion_06_</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>DuckTales (NES)</Game>
         </Games>
         <URLs>
@@ -9876,17 +9783,6 @@
         <Type>Component</Type>
         <Description>Autosplitting is available. (By DevilSquirrel)</Description>
         <Website>https://github.com/ShootMe/LiveSplit.TheBridge</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Devil May Cry 3: Special Edition</Game>
-            <Game>DMCSE</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/DMC3Splitter/master/DMC3Splitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal (By Auddy, Mysterion_06_, Hies)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -11647,16 +11543,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>The Evil Within</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/TEWSplitter/main/EvilWithinIGT.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter and IGT by Mattmatt and Mysterion_06_</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Donald Duck: Goin' Quackers</Game>
         </Games>
         <URLs>
@@ -11838,6 +11724,284 @@
         <Type>Script</Type>
         <Description>Auto-start, and auto-splitting at various points in the story are available (by ShikenNuggets and JohnStephenEvil)</Description>
     </AutoSplitter>
+    <!-- Auto splitters by Mysterion352 -->
+    <AutoSplitter>
+        <Games>
+            <Game>DMC</Game>
+            <Game>Devil May Cry</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/DMC1-Splitter/master/DMC1Autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/DMC1-Splitter/blob/master/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Devil May Cry 2</Game>
+            <Game>DMC2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/DMC2Splitter/master/DMC2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Auddy and Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Devil May Cry 3: Special Edition</Game>
+            <Game>DMCSE</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/DMC3Splitter/master/DMC3Splitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal (By Auddy, Mysterion352, Hies)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>DMC4SE</Game>
+            <Game>Devil May Cry 4: Special Edition (Steam)</Game>
+            <Game>Devil May Cry 4: Special Edition</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/DMC4SE-Autosplitter/master/DMC4SE_Splitter_V1.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with LRT by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/DMC4SE-Autosplitter/blob/master/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Resident Evil 4</Game>
+            <Game>Resident Evil 4 (Steam)</Game>
+            <Game>Resident Evil 4 Ultimate HD</Game>
+            <Game>RE4</Game>
+            <Game>Biohazard 4</Game>
+            <Game>Bio4</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Re4Splitter/main/RE4Splitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal are available. (By Wipefinger, Mysterion352, Yuushi)</Description>
+        <Website>https://github.com/Mysterion06/Re4Splitter/blob/main/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Resident Evil 5</Game>
+            <Game>Resident Evil 5 (Steam)</Game>
+            <Game>RE5</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Resident-Evil-5/main/Splitter</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal are available. (By Mysterion352 &amp; TheDementedSalad)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Resident Evil 5: Category Extensions</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Resident-Evil-5/main/Splitter</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitting and Load Removal are available. (By Auddy and Mysterion352)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>FINAL FANTASY TYPE-0</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/FFType0Splitter/main/FFType0_Splitter_Current.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with LRT by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/FFType0Splitter/blob/main/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>FINAL FANTASY VII REMAKE</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/FF7RSplitter/main/FF7R.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with LRT by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/FF7RSplitter/blob/main/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Final Fantasy X-2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/risal91/FF10-2-Autosplitter/main/FFX2ASL.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Loadremover by Risal07 and Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Final Fantasy XV</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/FF15LRT/main/FF15UpdatedLRT.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Loadremover by Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Ninja Gaiden Sigma</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/RazRaz94/autosplitters/main/NinjaGaidenSigmaAutoSplitterLRT_By%20Mysterion_06_.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and load removal is available. (by Mysterion352 and LonerHero)</Description>
+        <Website>https://www.speedrun.com/ninja_gaiden_sigma</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Ninja Gaiden Sigma 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/RazRaz94/autosplitters/main/Ninja%20Gaiden%20Sigma%202%20Autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for Ninja Gaiden Sigma 2 By LonerHero and Mysterion352</Description>
+        <Website>https://www.speedrun.com/ninja_gaiden_sigma_2</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>The Evil Within</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/TEWSplitter/main/EvilWithinIGT.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and IGT by Mattmatt and Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>The Evil Within 2</Game>
+            <Game>Evil Within 2</Game>
+            <Game>EW2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/TheEvilWithin2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto Splitter/Load Removal is available. (By Mysterion352, Kuno Demetries, Dread)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Vanquish</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Vanquish/main/Vanquish.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Loadremover by Fog and Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Bayonetta</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Bayonetta/main/Bayonetta.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with Loadremover by Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>SJBTT</Game>
+            <Game>Samurai Jack: Battle Through Time</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/MattPonton/SJGame/main/SJGame-Kamon.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Mysterion352 and PontonFSD</Description>
+        <Website>https://github.com/Mysterion06/SJGame/blob/master/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Thief (2014)</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Thi4fSplitter/main/Thi4fSplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with Loadremover for 1.0 32/64bit and 1.6 64bit by Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Yakuza: Like a Dragon</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/YakuzaLADSplitter/main/YakuzaLikeADragonSplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with Loadremover by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/YakuzaLADSplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Star Wars Jedi: Fallen Order</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Star-wars-jedi-fallen-order/main/SWJFO%20Autosplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter with LRT by Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Remothered: Broken Porcelain</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/Remothered-Broken-Porcelain/main/RemotheredBP.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description> Loadremover by Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Lost in Random</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/LostInRandom-Splitter/main/LostInRandomScript.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Loadremover and start by Mysterion352</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>GUN</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/GunSplitter/main/GunSplitter.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/GunSplitter/blob/main/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>The Lord of the Rings Gollum</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/GollumLOTR/main/GollumSplitter</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/GollumLOTR/blob/main/README.md</Website>
+    </AutoSplitter>
+    <!-- Auto splitters by Mysterion352 end -->
     <AutoSplitter>
         <Games>
             <Game>GTA2</Game>
@@ -13532,19 +13696,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>DMC4SE</Game>
-            <Game>Devil May Cry 4: Special Edition (Steam)</Game>
-            <Game>Devil May Cry 4: Special Edition</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/DMC4SE-Autosplitter/master/DMC4SE_Splitter_V1.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with LRT by Mysterion_06_</Description>
-        <Website>https://github.com/Mysterion06/DMC4SE-Autosplitter/blob/master/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Resident Evil: Code: Veronica X</Game>
             <Game>Biohazard Code: Veronica Kanzenban</Game>
         </Games>
@@ -13598,18 +13749,6 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitting, starting, and resetting available (by Ditmar Visser)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>DMC</Game>
-            <Game>Devil May Cry</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/DMC1-Splitter/master/DMC1Autosplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter by Mysterion_06_</Description>
-        <Website>https://github.com/Mysterion06/DMC1-Splitter/blob/master/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -13844,18 +13983,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>SJBTT</Game>
-            <Game>Samurai Jack: Battle Through Time</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/MattPonton/SJGame/main/SJGame-Kamon.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter by Mysterion_06_ and PontonFSD</Description>
-        <Website>https://github.com/Mysterion06/SJGame/blob/master/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Enclave</Game>
         </Games>
         <URLs>
@@ -13911,16 +14038,6 @@
         <Type>Script</Type>
         <Website>https://github.com/saiamphora/GenshinImpact-LTR</Website>
         <Description>Load time remover for Genshin Impact.</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Thief (2014)</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Thi4fSplitter/main/Thi4fSplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with Loadremover for 1.0 32/64bit and 1.6 64bit by Mysterion_06_</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -14201,17 +14318,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Yakuza: Like a Dragon</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/YakuzaLADSplitter/main/YakuzaLikeADragonSplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with Loadremover by Mysterion_06_</Description>
-        <Website>https://github.com/Mysterion06/YakuzaLADSplitter</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Rez (2004)</Game>
         </Games>
         <URLs>
@@ -14371,16 +14477,6 @@
         <Type>Script</Type>
         <Description>Simple autosplitter for SPOM (by Na'Guul)</Description>
         <Website>https://www.speedrun.com/user/NaGuul</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Resident Evil 5: Category Extensions</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Resident-Evil-5/main/Splitter</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Auto Splitting and Load Removal are available. (By Auddy and Mysterion_06_)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -14644,16 +14740,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Star Wars Jedi: Fallen Order</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Star-wars-jedi-fallen-order/main/SWJFO%20Autosplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with LRT by Mysterion_06_</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>WitchWay</Game>
         </Games>
         <URLs>
@@ -14876,16 +14962,6 @@
         <Type>Script</Type>
         <Website>https://github.com/WinterThunderSpeedrun/Autosplitters</Website>
         <Description>Autospliter with IGT for Lotus III on DOSBox 0.74-3 (manual start and reset required)</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Remothered: Broken Porcelain</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/Remothered-Broken-Porcelain/main/RemotheredBP.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description> Loadremover by Mysterion06</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -15191,16 +15267,6 @@
         <Type>Script</Type>
         <Description>IGT, as well as auto start/stop/reset. (by brododragon)</Description>
         <Website>https://github.com/brododragon/Jelly-Drift-Autosplitter/blob/main/JellyDrift.asl</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>Final Fantasy XV</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/FF15LRT/main/FF15UpdatedLRT.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Loadremover by Mysterion_06_</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -15718,16 +15784,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Final Fantasy X-2</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/risal91/FF10-2-Autosplitter/main/FFX2ASL.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter and Loadremover by Risal07 and Mysterion_06_</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Pirates of the Caribbean: At World's End</Game>
         </Games>
         <URLs>
@@ -16002,16 +16058,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Lost in Random</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/LostInRandom-Splitter/main/LostInRandomScript.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Loadremover and start by Mysterion_06_</Description>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Prototype</Game>
         </Games>
         <URLs>
@@ -16093,17 +16139,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>FINAL FANTASY VII REMAKE</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/FF7RSplitter/main/FF7R.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with LRT by Mysterion_06_</Description>
-        <Website>https://github.com/Mysterion06/FF7RSplitter/blob/main/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Sonic's Schoolhouse</Game>
         </Games>
         <URLs>
@@ -16141,17 +16176,6 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>FINAL FANTASY TYPE-0</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/FFType0Splitter/main/FFType0_Splitter_Current.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter with LRT by Mysterion_06_</Description>
-        <Website>https://github.com/Mysterion06/FFType0Splitter/blob/main/README.md</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
             <Game>Wrath Aeon of Ruin</Game>
             <Game>Wrath: Aeon of Ruin</Game>
         </Games>
@@ -16161,17 +16185,6 @@
         <Type>Script</Type>
         <Description>Auto start/split/reset. (By SabulineHorizon)</Description>
         <Website>https://github.com/SabulineHorizon/Autosplitters</Website>
-    </AutoSplitter>
-    <AutoSplitter>
-        <Games>
-            <Game>GUN</Game>
-        </Games>
-        <URLs>
-            <URL>https://raw.githubusercontent.com/Mysterion06/GunSplitter/main/GunSplitter.asl</URL>
-        </URLs>
-        <Type>Script</Type>
-        <Description>Autosplitter by Mysterion_06_</Description>
-        <Website>https://github.com/Mysterion06/GunSplitter/blob/main/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -17316,7 +17329,7 @@
             <URL>https://raw.githubusercontent.com/TheDementedSalad/Soul-Reaver-2-Autosplitter/main/LoKSR2%20Autosplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Timed via IGT (Load Remover) W/Autosplitter capabilities (by TheDementedSalad, Mysterion06)</Description>
+        <Description>Timed via IGT (Load Remover) W/Autosplitter capabilities (by TheDementedSalad, Mysterion352)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,18 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Sanguine Soul</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Sanguine%20Soul/sanguinesoul.asl</URL>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Sanguine%20Soul/SanguineSoul.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and load removal is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Himno</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15,7 +15,7 @@
             <Game>Hitman 3 Freelancer</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Hitman%203/hitman3.asl </URL>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Hitman%203/hitman3.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Load removal is available. (By diggity)</Description>
@@ -70,9 +70,11 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.Trepang2/main/Trepang2.asl</URL>
+            <URL>https://raw.githubusercontent.com/LiterallyMetaphorical/Livesplit.Trepang2/main/Trepang2.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>
-        <Description> Contains functionality for autostart, autosplit, and load removal (By Meta &amp; Diggity)</Description>
+        <Description>Contains functionality for autostart, autosplit, and load removal (By Meta &amp; diggity)</Description>
    </AutoSplitter>
    <AutoSplitter>    
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14184,7 +14184,7 @@
             <Game>LEGO Star Wars: The Complete Saga (PC/Console)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/melodyfast/LEGO-Autosplitters/main/TCS-Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/eroadhouse/TCSAutoSplitterLoadRemover/main/TCSAutosplitterLoadRemover.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto Splitting is available. (By Zac, P53, eroadhouse)</Description>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Spacky's Nightshift</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Vaqquixx8/autosplitters/main/spacky.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Removal and Autosplit is available (by vaqquixx8)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Stairway to Heaven's Gate</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18982,4 +18982,14 @@
         <Type>Script</Type>
         <Description>Load remover by kamil2050</Description>
     </AutoSplitter>
+        <AutoSplitter>
+        <Games>
+            <Game>LEGO Indiana Jones 2: The Adventure Continues</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Siedemnastek/Autosplitter/main/LIJ2Final.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and Load Removal Available (By Siedemnastek)</Description>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18835,4 +18835,25 @@
         <Description>Autosplitter and load remover for Pillars Of Light (by Narom42)</Description>
         <Website>https://github.com/mbourlet/pillarsOfLight-asl</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Kono Subarashii Sekai ni Syukufuku wo! Fukkatsu no Beldia</Game>
+            <Game>KonoSuba: Fukkatsu no Beldia</Game>   
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/kamil2050/ASL-scripts/main/KonoSuba%20Fukkatsu%20no%20Beldia%20load%20remover.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load remover by kamil2050</Description>
+    </AutoSplitter>
+           <AutoSplitter>
+        <Games>
+            <Game>Demon Slayer -Kimetsu no Yaiba- The Hinokami Chronicles</Game>  
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/kamil2050/ASL-scripts/main/Demon%20Slayer%20load%20remover.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load remover by kamil2050 and Nighlin</Description>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18960,4 +18960,16 @@
         <Description>Autosplitter for Timberman Classic Mode. Different goals can be selected in the settings. (By Felicien2B and Jean20B)</Description>
         <Website>https://www.speedrun.com/timberman</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>My Friendly Neighborhood</Game>
+            <Game>My Friendly Neighbourhood</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/My-Friendly-Neighborhood-Splitter/main/My%20Friendly%20Neighborhood.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Door Splitting available. Compare to IGT. (By TheDementedSalad)</Description>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -213,6 +213,17 @@
     </AutoSplitter>
     <AutoSplitter>    
         <Games>
+            <Game>The Building 71 Incident</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/The%20Building%2071%20Incident/building71.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and load removal is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>    
+        <Games>
             <Game>Exhibition of Memories</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,19 @@
 <AutoSplitters>
 	<AutoSplitter>
         <Games>
+            <Game>Moose Lost in the Woods</Game>
+            <Game>MLitW</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/Moose%20Lost%20in%20the%20Woods/MLitW.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter is available. (By Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/Moose%20Lost%20in%20the%20Woods/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Strike Force Heroes Remake</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1390,7 +1390,7 @@
             <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/main/LiveSplit.SouthParkStickOfTruth.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Remover, Autosplitter and Autostart/reset by streetbackguy</Description>
+        <Description>Load Remover and Autostart/reset by streetbackguy</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -1527,7 +1527,7 @@
             <URL>https://raw.githubusercontent.com/KunoDemetries/AutoSplitter/master/DeadRising3.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitter (By Kuno Demetries, StreetBackGuy)</Description>
+        <Description>Autosplitter (By Kuno Demetries, Streetbackguy)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18990,6 +18990,7 @@
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/TheDementedSalad/My-Friendly-Neighborhood-Splitter/main/My%20Friendly%20Neighborhood.asl</URL>
+            <URL>https://raw.githubusercontent.com/TheDementedSalad/My-Friendly-Neighborhood-Splitter/main/MFN.Settings.xml</URL>
             <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
         </URLs>
         <Type>Script</Type>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+    <AutoSplitter>
+        <Games>
+            <Game>Janitor Bleeds</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Janitor%20Bleeds/janitorbleeds.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load removal is available. (By diggity)</Description>
+    </AutoSplitter>
     <AutoSplitter>    
         <Games>
             <Game>Sniper Killer</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>The Masters Pupil</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ZeppelinGames/TheMastersPupilAutoSplit/main/the-masters-pupil.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart, split and reset for The Masters Pupil by Zeppelin</Description> 
+   </AutoSplitter>
+   <AutoSplitter>
+        <Games>
             <Game>Wretched Depths</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+    <AutoSplitter>
+        <Games>
+            <Game>null.</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/samjones246/null-asl/releases/latest/download/null_asl.wasm</URL>
+        </URLs>
+        <Type>Script</Type>
+	<ScriptType>AutoSplittingRuntime</ScriptType>
+        <Description>Auto start/split/reset and IGT supported. (By CaptainRektbeard)</Description>
+    </AutoSplitter>
      <AutoSplitter>
         <Games>
             <Game>En Garde! (Demo)</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -15883,10 +15883,10 @@
             <Game>POPPY PLAYTIME: CHAPTER 1</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/TitomakaniJr/AutoSplits/main/Poppy%20Playtime/PoppyPlaytime.asl</URL>
+            <URL>https://raw.githubusercontent.com/streetbackguy/AutoSplits/main/Poppy%20Playtime/PoppyPlaytime.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Poppy Playtime Chapter 1 Autosplitter and Load Remover. (By Poots N Doots)</Description>
+        <Description>Poppy Playtime Chapter 1 Load Remover by Streetbackguy</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18991,6 +18991,8 @@
         <Games>
             <Game>Kono Subarashii Sekai ni Syukufuku wo! Fukkatsu no Beldia</Game>
             <Game>KonoSuba: Fukkatsu no Beldia</Game>
+            <Game>Kono Subarashii Sekai ni Syukufuku wo! Fukkatsu no Beldia Category Extension</Game>
+            <Game>KonoSuba: Fukkatsu no Beldia Category Extension</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/kamil2050/ASL-scripts/main/KonoSuba%20Fukkatsu%20no%20Beldia%20load%20remover.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18879,4 +18879,14 @@
         <Type>Script</Type>
         <Description>Load remover by kamil2050 and Nighlin</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Plazma Burst 2</Game>  
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/XcapeEst/LiveSplit.PlazmaBurst2/main/plazmaburst2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Removal and Auto Splitting is available. (by xCape)</Description>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+	<AutoSplitter>    
+        <Games>
+            <Game>Duck Simulator 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/sandwichmanlovertm/ALS/main/Duck%20Simulator%202.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>start and splitting. for the 3 routes and 4 chapters... no resetting</Description>
+    	</AutoSplitter>
 	<AutoSplitter>
         <Games>
             <Game>DMZ: North Korea</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4803,6 +4803,7 @@
             <Game>Lego Batman</Game>
             <Game>Lego Batman The Videogame</Game>
             <Game>Lego Batman: The Videogame</Game>
+            <Game>Lego Batman: The Videogame Category Extensions</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/Biksell/asl/main/LEGO%20Batman/LEGOBatman.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Wretched Depths</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/main/Livesplit.WretchedDepths.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart and Load Removal by Streetbackguy</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Ratchet &amp; Clank: Rift Apart</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18765,4 +18765,15 @@
 	<Description>NEO: The World Ends With You Autosplitter and Load Remover (by Tedder)</Description>
 	<Website>https://www.speedrun.com/neotwewy</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Ys IX: Monstrum Nox</Game>
+        </Games>
+        <URLs>
+            <URL>https://gist.githubusercontent.com/JaddoSRL/e59dc11fb7d32a0e821859374d1631d6/raw/Ys%25209%2520Load%2520Remover.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load Remover for Ys IX: Monstrum Nox (by Jaddo)</Description>
+        <Website>https://gist.github.com/JaddoSRL/e59dc11fb7d32a0e821859374d1631d6</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2571,9 +2571,9 @@
             <Game>Sonic Origins</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicOrigins/main/LiveSplit.SonicOrigins.asl</URL>
+            <URL>https://raw.githubusercontent.com/SonicSpeedrunning/LiveSplit.SonicOrigins/main/Components/LiveSplit.SonicOrigins.dll</URL>
         </URLs>
-        <Type>Script</Type>
+        <Type>Component</Type>
         <Description>Autosplitting and in-game timing with customizable options according to speedrun.com rulings (by Jujstme)</Description>
         <Website>https://github.com/SonicSpeedrunning/LiveSplit.SonicOrigins</Website>
     </AutoSplitter>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -43,7 +43,7 @@
         <Description>Autosplitter is available. (By Biksel)</Description>
         <Website>https://github.com/Biksell/asl/blob/main/LEGO%20Alpha%20Team/README.md</Website>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>DREDGE</Game>
         </Games>
@@ -79,7 +79,7 @@
         <Description>Autosplitter is available. (By Biksel)</Description>
         <Website>https://github.com/Biksell/asl/blob/main/Strike%20Force%20Heroes%20Remake/README.md</Website>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Duck Simulator 2</Game>
         </Games>
@@ -155,7 +155,7 @@
         <Type>Script</Type>
         <Description>Load removal is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Sniper Killer</Game>
         </Games>
@@ -177,7 +177,7 @@
         <Type>Script</Type>
         <Description>Autosplitting is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Dead From Beyond</Game>
         </Games>
@@ -188,7 +188,7 @@
         <Type>Script</Type>
         <Description>Auto start/split is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Trepang2</Game>
         </Games>
@@ -200,7 +200,7 @@
         <Type>Script</Type>
         <Description>Contains functionality for autostart, autosplit, and load removal (By Meta &amp; diggity)</Description>
    </AutoSplitter>
-   <AutoSplitter>    
+   <AutoSplitter>
         <Games>
             <Game>Fractured Minds</Game>
         </Games>
@@ -210,7 +210,7 @@
         <Type>Script</Type>
         <Description>AutoStart/Split/End aswell as Load Remover intended for the Amazon Prime version of the game. (By JayC_)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Bionic Commando (2009)</Game>
         </Games>
@@ -220,7 +220,7 @@
         <Type>Script</Type>
         <Description>Autostart and Load Remover by Streetbackguy</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
 	<Games>
             <Game>Spider-Man: Shattered Dimensions</Game>
         </Games>
@@ -230,7 +230,7 @@
         <Type>Script</Type>
         <Description>Autosplitting and Load Removal by Mattmatt</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Porter</Game>
         </Games>
@@ -240,7 +240,7 @@
         <Type>Script</Type>
         <Description>Auto start/split/reset and IGT supported. (By CaptainRektbeard)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Nomad</Game>
         </Games>
@@ -250,7 +250,7 @@
         <Type>Script</Type>
         <Description>Auto start/split supported. (By CaptainRektbeard)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
         	<Game>My Friend Peppa Pig</Game>
         </Games>
@@ -261,7 +261,7 @@
         <Type>Script</Type>
         <Description>Autostart and Load Remover by Streetbackguy</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
         	<Game>Hearthstone</Game>
 		<Game>Curse of Naxxramas</Game>
@@ -300,7 +300,7 @@
 	<Type>Script</Type>
 	<Description>Autostart/split/reset for PC version to 1 on 1 Kombat (by Marius150PL)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Poly Bridge 3</Game>
         </Games>
@@ -312,7 +312,7 @@
         <Type>Script</Type>
         <Description>Auto start/split is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Poly Bridge</Game>
         </Games>
@@ -324,7 +324,7 @@
         <Type>Script</Type>
         <Description>Auto start/split is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Gang Beasts</Game>
         </Games>
@@ -335,7 +335,7 @@
         <Type>Script</Type>
         <Description>Auto start/split and IGT available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Scars Above</Game>
         </Games>
@@ -345,7 +345,7 @@
         <Type>Script</Type>
         <Description>Load removal is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>The Outlast Trials</Game>
 	    <Game>Outlast Trials</Game>
@@ -356,7 +356,7 @@
         <Type>Script</Type>
         <Description>Auto Splitter and Load Remover (By KunoDemetries)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Amanda The Adventurer</Game>
         </Games>
@@ -378,7 +378,7 @@
         <ScriptType>AutoSplittingRuntime</ScriptType>
         <Description>Load remover (by Jujstme)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>MEATGRINDER</Game>
         </Games>
@@ -389,7 +389,7 @@
         <Type>Script</Type>
         <Description>Load removal available. (By diggity &amp; Meta)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Viewfinder</Game>
         </Games>
@@ -400,7 +400,7 @@
         <Type>Script</Type>
         <Description>Auto start/split and load removal available. (By CaptainRektbeard)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>The Building 71 Incident</Game>
         </Games>
@@ -411,7 +411,7 @@
         <Type>Script</Type>
         <Description>Autosplitting and load removal is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Exhibition of Memories</Game>
         </Games>
@@ -423,7 +423,7 @@
         <Type>Script</Type>
         <Description>Autosplitting and load removal is available. (By diggity)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Toppys Workshop</Game>
             <Game>Toppy's Workshop</Game>
@@ -465,7 +465,7 @@
         <Type>Script</Type>
         <Description>Auto start/split and load removal available. (By CaptainRektbeard)</Description>
     </AutoSplitter>
-    <AutoSplitter>    
+    <AutoSplitter>
         <Games>
             <Game>Rewind or Die</Game>
         </Games>
@@ -16920,6 +16920,19 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Shady Knight</Game>
+            <Game>Shady Knight Demo</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/just-ero/asl/raw/main/Shady%20Knight/ShadyKnight.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Only supports IL runs. Starts, resets automatically. Splits when finishing a level. (by Ero)</Description>
+        <Website>https://github.com/just-ero/asl/tree/main/Shady%20Knight</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Sonic Project '06</Game>
             <Game>Sonic Project 06</Game>
             <Game>Sonic P06</Game>
@@ -18895,7 +18908,7 @@
     <AutoSplitter>
         <Games>
             <Game>Kono Subarashii Sekai ni Syukufuku wo! Fukkatsu no Beldia</Game>
-            <Game>KonoSuba: Fukkatsu no Beldia</Game>   
+            <Game>KonoSuba: Fukkatsu no Beldia</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/kamil2050/ASL-scripts/main/KonoSuba%20Fukkatsu%20no%20Beldia%20load%20remover.asl</URL>
@@ -18905,7 +18918,7 @@
     </AutoSplitter>
            <AutoSplitter>
         <Games>
-            <Game>Demon Slayer -Kimetsu no Yaiba- The Hinokami Chronicles</Game>  
+            <Game>Demon Slayer -Kimetsu no Yaiba- The Hinokami Chronicles</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/kamil2050/ASL-scripts/main/Demon%20Slayer%20load%20remover.asl</URL>
@@ -18915,7 +18928,7 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Plazma Burst 2</Game>  
+            <Game>Plazma Burst 2</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/XcapeEst/LiveSplit.PlazmaBurst2/main/plazmaburst2.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Hitman 3 Freelancer</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Hitman%203/hitman3.asl </URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load removal is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Janitor Bleeds</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,18 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Himno</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/aaw4421/himno-autosplitter/master/himno.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter is available. (by BlueCrystal)</Description>
+        <Website>https://github.com/aaw4421/himno-autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>The Ball Pit</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Viva Piñata</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/main/LiveSplit.VivaPinata.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart, Load Removal and Autosplit by Streetbackguy</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Spacky's Nightshift</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18730,4 +18730,15 @@
         <Description>Oblivion Override (PC) Autosplitter (By CptBrian and Ero)</Description>
         <Website>https://www.speedrun.com/oblivion_override</Website>
     </AutoSplitter>
+    <AutoSplitter>
+	<Games>
+	    <Game>Planet of Lana</Game>
+	</Games>
+	<URLs>
+	    <URL>https://raw.githubusercontent.com/PietHelzel/Planet-of-Lana-Autosplitter/main/Planet%20of%20Lana.asl</URL>
+	</URLs>
+	<Type>Script</Type>
+	<Description>Planet of Lana Autosplitter and Load Remover (by Penta)</Description>
+	<Website>https://www.speedrun.com/planet_of_lana</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12,6 +12,16 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
+            <Game>Porkchop's Adventure</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/derric-young/Porkchop-s-Adventure-Autosplitter/main/porkchop1.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting Avalible with Toggleable Splits. by Derric</Description> 
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Bloodline</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,18 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Raw Nerve</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/Raw%20Nerve/RawNerve.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and IGT is available. (By Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/Raw%20Nerve/README.md</Website>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>null.</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -14935,10 +14935,10 @@
             <Game>LEGO Indiana Jones: The Original Adventures</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/melodyfast/LEGO-Autosplitters/main/LIJ-Autosplitter.asl</URL>
+            <URL>https://raw.githubusercontent.com/Siedemnastek/Autosplitter/main/LIJ1.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Autosplitting is available. (By Elle)</Description>
+        <Description>Autosplitting is available. (By Siedemnastek)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>    
         <Games>
+            <Game>Sniper Killer</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Sniper%20Killer/sniperkillerdemo.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and load removal is available (Demo Only). (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>    
+        <Games>
             <Game>Dead From Beyond</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <AutoSplitters>
+    <AutoSplitter>
+        <Games>
+            <Game>LEGO Alpha Team</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/LEGO%20Alpha%20Team/LEGOAlphaTeam.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter is available. (By Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/LEGO%20Alpha%20Team/README.md</Website>
+    </AutoSplitter>
     <AutoSplitter>    
         <Games>
             <Game>DREDGE</Game>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -5,10 +5,10 @@
             <Game>Ratchet &amp; Clank: Rift Apart</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/Syn34/Rift-Apart-Autosplitter/main/Riftsplitter%20v13%20by%20Jasper%20%26%20Sin.asl</URL>
+            <URL>https://raw.githubusercontent.com/Syn34/Rift-Apart-Autosplitter/main/Riftsplitter.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Supports Splitting and Load Removal for v1.728.0.0</Description> 
+        <Description>Riftsplitter by Jasper and Sin (Splitting/Load Removal)</Description> 
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -13689,6 +13689,17 @@
         <Description>Automatic start, room triggers, gates, achievements, encounters and more. By Henpemaz and ICED</Description>
     </AutoSplitter>
     <AutoSplitter>
+    <Games>
+        <Game>Rain World: Downpour</Game>
+    </Games>
+    <URLs>
+        <URL>https://raw.githubusercontent.com/rekadoodle/Rain-World-Autosplitter/main/main.asl</URL>
+    </URLs>
+    <Type>Script</Type>
+    <Description>WIP Autosplitter for Rain World 1.9 (Downpour) by rek</Description>
+    <Website>https://github.com/rekadoodle/Rain-World-Autosplitter</Website>
+    </AutoSplitter>
+    <AutoSplitter>
         <Games>
             <Game>Bright Memory - Episode 1</Game>
         </Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4139,13 +4139,21 @@
     </AutoSplitter>
     <AutoSplitter>
         <Games>
-            <Game>Aperture Tag</Game>
             <Game>Portal 2</Game>
-            <Game>Portal 2 Speedrun Mod</Game>
             <Game>Portal 2 Category Extensions</Game>
+            <Game>Portal 2 Speedrun Mod</Game>
             <Game>Portal Reloaded</Game>
             <Game>Portal Stories: Mel</Game>
+            <Game>Aperture Tag</Game>
             <Game>Thinking with Time Machine</Game>
+            <Game>Aperture Ireland</Game>
+            <Game>Designed For Danger</Game>
+            <Game>Welcome Back</Game>
+            <Game>Memories</Game>
+            <Game>Dilapidation</Game>
+            <Game>P1 Done P2</Game>
+            <Game>Mind Escape</Game>
+            <Game>Portal: Unity Reboot</Game>
         </Games>
         <URLs>
             <URL>https://s.portal2.sr/asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18776,4 +18776,16 @@
         <Description>Load Remover for Ys IX: Monstrum Nox (by Jaddo)</Description>
         <Website>https://gist.github.com/JaddoSRL/e59dc11fb7d32a0e821859374d1631d6</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Pillars Of Light</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mbourlet/pillarsOfLight-asl/main/pillarsOfLight.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter and load remover for Pillars Of Light (by Narom42)</Description>
+        <Website>https://github.com/mbourlet/pillarsOfLight-asl</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18924,4 +18924,15 @@
         <Description>Autosplitter is available. (By neon_uriel)</Description>
         <Website>https://github.com/neon-uriel/asl/blob/main/syobon_action/README.md</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Timberman</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Felicien2B/TimbermanASL/main/timberman.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter for Timberman Classic Mode. Different goals can be selected in the settings. (By Felicien2B and Jean20B)</Description>
+        <Website>https://www.speedrun.com/timberman</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -16922,6 +16922,7 @@
         <Games>
             <Game>Shady Knight</Game>
             <Game>Shady Knight Demo</Game>
+            <Game>Shady Knight Demos</Game>
         </Games>
         <URLs>
             <URL>https://github.com/just-ero/asl/raw/main/Shady%20Knight/ShadyKnight.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -11586,20 +11586,20 @@
             <Game>Preflight Panic</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/makkebakke/Autosplitters/master/LiveSplit.PreflightPanic.asl</URL>
+            <URL>https://raw.githubusercontent.com/KinzyKenzie/Autosplitters/master/LiveSplit.PreflightPanic.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Start and Auto Split are available (by Archmagus &amp; Makkebakke)</Description>
+        <Description>Auto Start and Auto Split are available (by Archmagus &amp; KinzyKenzie)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
             <Game>Brütal Legend</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/makkebakke/Autosplitters/master/LiveSplit.BrutalLegend.asl</URL>
+            <URL>https://raw.githubusercontent.com/KinzyKenzie/Autosplitters/master/LiveSplit.BrutalLegend.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Auto Splitting available (by Makkebakke)</Description>
+        <Description>Auto Splitting available (by KinzyKenzie)</Description>
     </AutoSplitter>
     <AutoSplitter>
         <Games>
@@ -12311,7 +12311,7 @@
             <Game>RoboCop (2003)</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/makkebakke/Autosplitters/master/LiveSplit.RoboCop2K3.asl</URL>
+            <URL>https://raw.githubusercontent.com/KinzyKenzie/Autosplitters/master/LiveSplit.RoboCop2K3.asl</URL>
         </URLs>
         <Type>Script</Type>
         <Description>Auto-splitting, start, and load removal are available.</Description>
@@ -19051,5 +19051,16 @@
         </URLs>
         <Type>Script</Type>
         <Description>Autosplitter and Load Removal Available (By Siedemnastek)</Description>
+    </AutoSplitter>
+	<AutoSplitter>
+        <Games>
+            <Game>Wholesome Slaughter</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/kenchie-sr/wholesome-slaughter-livesplit/main/LiveSplit.WholesomeSlaughter.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplit and Load Removal Available (By KinzyKenzie)</Description>
     </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,18 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Lust From Beyond - Scarlet</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Lust%20From%20Beyond%20-%20Scarlet/lustfrombeyondscarlet.asl</URL>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Lust%20From%20Beyond%20-%20Scarlet/LFBScarlet.Settings.xml</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and load removal is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Viva Piñata</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,16 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Bloodline</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/streetbackguy/Autosplitter-Projects/main/Livesplit.Bloodline.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart/split and Load Removal by Streetbackguy</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Pogo3D</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>The Ball Pit</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/The%20Ball%20Pit/theballpit.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitting and load removal is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Lust From Beyond - Scarlet</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Pogo3D</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Pogo3D/pogo3d.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Auto start/split is available. (By diggity)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Sanguine Soul</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18597,4 +18597,16 @@
         <Description>Autosplitter with Start, Reset and configurable Splits (by traumvogel, t0mz3r, NeKRooZz and wRadion)</Description>
         <Website>https://github.com/Edgarflc/autosplitter_only_up</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Oblivion Override</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/CptBrian/Autosplitters/master/OblivionOverride.asl</URL>
+	    <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Oblivion Override (PC) Autosplitter (By CptBrian and Ero)</Description>
+        <Website>https://www.speedrun.com/oblivion_override</Website>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -26,6 +26,7 @@
     <AutoSplitter>
         <Games>
             <Game>Lust From Beyond - Scarlet</Game>
+            <Game>Lust From Beyond: Scarlet</Game>
         </Games>
         <URLs>
             <URL>https://raw.githubusercontent.com/mitchell-merry/autosplitters/main/Lust%20From%20Beyond%20-%20Scarlet/lustfrombeyondscarlet.asl</URL>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -18972,4 +18972,14 @@
         <Type>Script</Type>
         <Description>Door Splitting available. Compare to IGT. (By TheDementedSalad)</Description>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Uwolnić Zozole</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/kamil2050/ASL-scripts/main/Uwolnić%20Zozole%20load%20remover.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Load remover by kamil2050</Description>
+    </AutoSplitter>
 </AutoSplitters>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,17 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>The Masters Pupil Demo</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/ZeppelinGames/TheMastersPupilDemoAutoSplit/main/the-masters-pupil-demo.asl</URL>
+            <URL>https://github.com/just-ero/asl-help/raw/main/lib/asl-help</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autostart, split and reset for The Masters Pupil Demo by Zeppelin</Description> 
+   </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>The Masters Pupil</Game>
         </Games>
         <URLs>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -12134,6 +12134,17 @@
         <Description>Autosplitter by Mysterion352</Description>
         <Website>https://github.com/Mysterion06/GollumLOTR/blob/main/README.md</Website>
     </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Pseudoregalia</Game>
+        </Games>
+        <URLs>
+            <URL>https://raw.githubusercontent.com/Mysterion06/PseudoregaliaSplitter/main/Pseudoregalia.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Autosplitter by Mysterion352</Description>
+        <Website>https://github.com/Mysterion06/PseudoregaliaSplitter/blob/main/README.md</Website>
+    </AutoSplitter>
     <!-- Auto splitters by Mysterion352 end -->
     <AutoSplitter>
         <Games>

--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -4773,11 +4773,11 @@
             <Game>Lego Batman: The Videogame</Game>
         </Games>
         <URLs>
-            <URL>https://raw.githubusercontent.com/drtchops/asl/master/legobatman.asl</URL>
+            <URL>https://raw.githubusercontent.com/Biksell/asl/main/LEGO%20Batman/LEGOBatman.asl</URL>
         </URLs>
         <Type>Script</Type>
-        <Description>Load Removal is available. (By DrTChops)</Description>
-        <Website>https://github.com/drtchops/asl/blob/master/README.md</Website>
+        <Description>Autosplitting and Load removal is available. (By Siedemnastek &amp; Biksel)</Description>
+        <Website>https://github.com/Biksell/asl/blob/main/LEGO%20Batman/README.md</Website>
     </AutoSplitter>
     <AutoSplitter>
         <Games>

--- a/README.md
+++ b/README.md
@@ -24,17 +24,31 @@
 	- [Built-in Functions](#built-in-functions)
 	- [Testing your Script](#testing-your-script)
 		- [Debugging](#debugging)
+- [Sandboxed Auto Splitters](#sandboxed-auto-splitters)
 - [Adding an Auto Splitter](#adding-an-auto-splitter)
 - [Additional Resources](#additional-resources)
 
 <!-- /TOC -->
 
-LiveSplit has integrated support for Auto Splitters. An Auto Splitter can be one of the following:
+LiveSplit has integrated support for Auto Splitters. An Auto Splitter can be one
+of the following:
 * A Script written in the Auto Splitting Language (ASL).
+* A WebAssembly module that uses the new cross-platform, sandboxed Auto
+  Splitting Runtime.
 * A LiveSplit Component written in any .NET compatible language.
-* A third party application communicating with LiveSplit through the LiveSplit  Server.
+* A third party application communicating with LiveSplit through the LiveSplit
+  Server.
 
-At the moment LiveSplit can automatically download and activate Auto Splitters that are LiveSplit Components or ASL Scripts. Support for applications using the LiveSplit Server is planned, but is not yet available.
+LiveSplit can automatically download and activate Auto Splitters that are
+LiveSplit components, WebAssembly modules, or ASL scripts.
+
+Currently we recommend writing an ASL script, which has the most extensive
+support for all the features you might need. If you are feeling more
+adventurous, you can start looking into writing an auto splitter for the new
+cross-platform, sandboxed Auto Splitting Runtime
+[here](#sandboxed-auto-splitters). Sandboxed auto splitters are currently more
+limited, but they will become the main way to write auto splitters in the
+future.
 
 ## Features of an Auto Splitter
 
@@ -114,7 +128,7 @@ VARIABLE_TYPE VARIABLE_NAME : "BASE_MODULE", OFFSET, OFFSET, OFFSET, ...;
 The variable type `VARIABLE_TYPE` describes the type of the value found at the pointer path. It can be one of the following:
 
 | Type             | Description                |
-|------------------|----------------------------|
+| ---------------- | -------------------------- |
 | sbyte            | Signed 8-bit integer       |
 | byte             | Unsigned 8-bit integer     |
 | short            | Signed 16-bit integer      |
@@ -416,6 +430,37 @@ For errors, you can also check the Windows Event Logs, which you can find via:
 Control Panel ➞ Search for Event Viewer ➞ Open it ➞ Windows Logs ➞ Application ➞ Find the LiveSplit Errors
 
 Some might be unrelated to the Script, but it'll be fairly obvious which ones are caused by you.
+
+## Sandboxed Auto Splitters
+
+It is also possible to provide an auto splitter as a WebAssembly module. These
+auto splitters get executed through the new Auto Splitter Runtime, which has
+several benefits:
+1. The runtime is cross platform. It can run on Windows, macOS, and Linux.
+2. The runtime is sandboxed. All auto splitters running on the new runtime are
+   fully sandboxed and it's impossible for an auto splitter to harm the user.
+   The user is also protected from the auto splitter crashing, which will not
+   affect the timer itself.
+3. The auto splitters can be written in many different languages, such as Rust,
+   C, C++, JavaScript, TypeScript, Go, and more.
+4. The runtime isn't tied to just LiveSplit and can be used with other timers or
+   even run inside of the [Auto Splitting Runtime
+   Debugger](https://github.com/CryZe/asr-debugger) which allows you to debug
+   the auto splitters more easily.
+
+There is one downside to auto splitters written for the new runtime however. The
+fact that they are sandboxed and cross platform means that there may be certain
+functionality, that you may need for your auto splitter to work, that is not
+supported yet.
+
+Right now Rust is the language that has the best support. If you want to create
+an auto splitter using the new runtime, you can follow the instructions over
+here: [Rust Auto Splitter
+Template](https://github.com/LiveSplit/auto-splitter-template)
+
+If you need help writing an auto splitter for the new runtime, make sure to
+visit the `#auto-splitting-v2` channel in the [Speedrun Tool Development
+Discord](https://discord.gg/N6wv8pW).
 
 ## Adding an Auto Splitter
 


### PR DESCRIPTION
Adding in SRC game names for mods supported by the Portal 2 autosplitter.

If you are adding or modifying an Auto Splitter, please fill out this checklist:
- [X] My Auto Splitter does not contain any malicious functionality and I'm entirely responsible for any damages myself. (Any kind of abuse in an Auto Splitter will result in an immediate ban.)
- [X] I am not replacing an existing Auto Splitter by a different author, or I have received permission from the author to replace the existing Auto Splitter.
- [X] The Auto Splitter has an open source license that allows anyone to fork and host it.
